### PR TITLE
Fix menu references

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -3,7 +3,7 @@
         "id": "edit",
         "children":
         [
-        	{ "id": "wrap" },
+            { "id": "wrap" },
             { "command": "figlet", "caption": "FIGlet" }
         ]
     },
@@ -24,7 +24,7 @@
                             {
                                 "command": "open_file",
                                 "args": {
-                                    "file": "${packages}/Sublime-FIGlet/Default (Windows).sublime-keymap",
+                                    "file": "${packages}/ASCII Decorator (FIGlet)/Default (Windows).sublime-keymap",
                                     "platform": "Windows"
                                 },
                                 "caption": "Key Bindings – Default"
@@ -32,7 +32,7 @@
                             {
                                 "command": "open_file",
                                 "args": {
-                                    "file": "${packages}/Sublime-FIGlet/Default (OSX).sublime-keymap",
+                                    "file": "${packages}/ASCII Decorator (FIGlet)/Default (OSX).sublime-keymap",
                                     "platform": "OSX"
                                 },
                                 "caption": "Key Bindings – Default"
@@ -40,7 +40,7 @@
                             {
                                 "command": "open_file",
                                 "args": {
-                                    "file": "${packages}/Sublime-FIGlet/Default (Linux).sublime-keymap",
+                                    "file": "${packages}/ASCII Decorator (FIGlet)/Default (Linux).sublime-keymap",
                                     "platform": "Linux"
                                 },
                                 "caption": "Key Bindings – Default"
@@ -48,7 +48,7 @@
                             {
                                 "command": "open_file",
                                 "args": {
-                                    "file": "${packages}/Sublime-FIGlet/Default (Windows).sublime-keymap",
+                                    "file": "${packages}/User/Default (Windows).sublime-keymap",
                                     "platform": "Windows"
                                 },
                                 "caption": "Key Bindings – User"
@@ -56,7 +56,7 @@
                             {
                                 "command": "open_file",
                                 "args": {
-                                    "file": "${packages}/Sublime-FIGlet/Default (OSX).sublime-keymap",
+                                    "file": "${packages}/User/Default (OSX).sublime-keymap",
                                     "platform": "OSX"
                                 },
                                 "caption": "Key Bindings – User"
@@ -64,7 +64,7 @@
                             {
                                 "command": "open_file",
                                 "args": {
-                                    "file": "${packages}/Sublime-FIGlet/Default (Linux).sublime-keymap",
+                                    "file": "${packages}/User/Default (Linux).sublime-keymap",
                                     "platform": "Linux"
                                 },
                                 "caption": "Key Bindings – User"


### PR DESCRIPTION
Based on your submission to package control, I mapped the default key maps to Packages/ASCII Decorator (FIGlet) (this is where package control is going to install it), and the user key maps to Packages/User.
