### PR TITLE
Made the relative import of pyfiglet compatible for both Python 2 and 3.

### DIFF
--- a/ASCII-Decorator.py
+++ b/ASCII-Decorator.py
@@ -1,5 +1,8 @@
-import sublime, sublime_plugin, os, re
-from .pyfiglet import Figlet
+import sublime, sublime_plugin, os, re, sys
+if sys.version_info < (3,0,0):
+	from pyfiglet import Figlet
+else:
+	from .pyfiglet import Figlet
 
 class FigletCommand( sublime_plugin.TextCommand ):
 	"""


### PR DESCRIPTION
The Python 3 changes made the plugin not usable for ST2. I added a fix to make it usable for both versions.
