### PR TITLE
Update ASCII-Decorator.py

### DIFF
--- a/ASCII-Decorator.py
+++ b/ASCII-Decorator.py
@@ -205,13 +205,6 @@ class FigletFavoritesCommand( sublime_plugin.TextCommand ):
                 }
             )
 
-    def is_enabled(self):
-        enabled = False
-        for s in self.view.sel():
-            if s.size() or self.view.word(s).size():
-                enabled = True
-        return enabled
-
 
 class FigletMenuCommand( sublime_plugin.TextCommand ):
     def run( self, edit ):
@@ -293,26 +286,12 @@ class FigletMenuCommand( sublime_plugin.TextCommand ):
                 }
             )
 
-    def is_enabled(self):
-        enabled = False
-        for s in self.view.sel():
-            if s.size() or self.view.word(s).size():
-                enabled = True
-        return enabled
-
 
 class FigletDefaultCommand( sublime_plugin.TextCommand ):
     def run(self, edit):
         settings = sublime.load_settings('ASCII-Decorator.sublime-settings')
         font = settings.get('ascii_decorator_font', "slant")
         self.view.run_command("figlet", {"font": font})
-
-    def is_enabled(self):
-        enabled = False
-        for s in self.view.sel():
-            if s.size() or self.view.word(s).size():
-                enabled = True
-        return enabled
 
 
 class FigletCommand( sublime_plugin.TextCommand ):
@@ -338,11 +317,15 @@ class FigletCommand( sublime_plugin.TextCommand ):
 
         # Loop through user selections.
         for currentSelection in self.view.sel():
+            lineA = self.view.line( currentSelection.a )
+            lineB = self.view.line( currentSelection.b )
             # Decorate the selection to ASCII Art.
-            if not currentSelection.size(): # Select word under cursor if selection is empty
-                currentSelection = self.view.word(currentSelection)
-            if currentSelection.size():
-                newSelections.append( self.decorate( self.edit, currentSelection ) )
+            if lineA == lineB: # single line selection
+                newSelections.append( self.decorate( self.edit, lineA ) )
+            else: # multi line selection
+                for line in reversed ( self.view.lines( currentSelection ) ):
+                    if self.view.substr( line ).strip() != "":
+                        newSelections.append( self.decorate( self.edit, line ) )
 
         # Clear selections since they've been modified.
         self.view.sel().clear()


### PR DESCRIPTION
Related to [__my rebuttal of pull request #24__](https://github.com/viisual/ASCII-Decorator/pull/24#issuecomment-204847444).

&nbsp;

I updated the selection loop @ `ASCII-Decorator/FigletCommand` to:

* automatically use the full line text of each selected region
* run `self.decorate` at each line of a multi-line selection *( excluding blank lines )*

*( the previous functionality would merge multiple lines into a single line )*

&nbsp;

The only issue I noticed is:

* the process you use to select the converted text does not work for the multi-line addition

&nbsp;

Also - I removed the `is_enabled` methods, because they were never called & it seems that all related functionality is handled at the selection loop.

&nbsp;

Here are some GIF demos that illustrate previous & current functionality:

### Before Pull Request:

![animation 1](https://cloud.githubusercontent.com/assets/10906415/14230193/4217f7c6-f91b-11e5-8a75-b137e6a771e9.gif)

### After Pull Request:
*( shows: [1] with multiple carets, no selected text [2] single selection with multiple lines )*

![animation 2](https://cloud.githubusercontent.com/assets/10906415/14230194/48021d6a-f91b-11e5-871d-257d7c746801.gif)
