### PR TITLE
Added "Generate Font Test" from selected text

### DIFF
--- a/ASCII Decorator.py
+++ b/ASCII Decorator.py
@@ -34,10 +34,17 @@ class FontPreviewGeneratorCommand(sublime_plugin.WindowCommand):
 
             selection = selections[0]
             line_a = view.line( selection.a )
-            line_b = view.line( selection.b )
-            if line_a != line_b: return
+            line_b = view.line( selection.a )
 
-            text = view.substr( selection )
+            if line_a != line_b:
+                return
+
+            if selection.a == selection.b:
+                source_region = line_a
+            else:
+                source_region = selection
+
+            text = view.substr( source_region )
             text = text.strip()
 
             if text == "":

--- a/ASCII Decorator.py
+++ b/ASCII Decorator.py
@@ -27,24 +27,24 @@ class FontPreviewGeneratorCommand(sublime_plugin.WindowCommand):
 
             view = self.window.active_view()
             selections = view.sel()
-            region_count = len( selections )
+            regionCount = len( selections )
 
-            if region_count == 0 or region_count > 1:
+            if regionCount == 0 or regionCount > 1:
                 return
 
             selection = selections[0]
-            line_a = view.line( selection.a )
-            line_b = view.line( selection.a )
+            line_A = view.line( selection.a )
+            line_B = view.line( selection.b )
 
-            if line_a != line_b:
+            if line_A != line_B:
                 return
 
             if selection.a == selection.b:
-                source_region = line_a
+                sourceRegion = line_A
             else:
-                source_region = selection
+                sourceRegion = selection
 
-            text = view.substr( source_region )
+            text = view.substr( sourceRegion )
             text = text.strip()
 
             if text == "":
@@ -342,15 +342,22 @@ class FigletCommand( sublime_plugin.TextCommand ):
             comment_style, width, justify, direction, flip, reverse
         )
 
-        # Loop through user selections.
-        for currentSelection in self.view.sel():
-            lineA = self.view.line( currentSelection.a )
-            lineB = self.view.line( currentSelection.b )
-            # Decorate the selection to ASCII Art.
-            if lineA == lineB: # single line selection
-                newSelections.append( self.decorate( self.edit, lineA ) )
+        # Loop through user selections & decorate the selections to ASCII Art.
+        for selection in self.view.sel():
+
+            line_A = self.view.line( selection.a )
+            line_B = self.view.line( selection.b )
+
+            if  line_A == line_B \
+            and selection.a == selection.b: # use caret line
+                newSelections.append( self.decorate( self.edit, line_A ) )
+
+            elif line_A == line_B \
+            and  selection.a != selection.b: # use selection
+                newSelections.append( self.decorate( self.edit, selection ) )
+
             else: # multi line selection
-                for line in reversed ( self.view.lines( currentSelection ) ):
+                for line in reversed ( self.view.lines( selection ) ):
                     if self.view.substr( line ).strip() != "":
                         newSelections.append( self.decorate( self.edit, line ) )
 

--- a/ASCII Decorator.py
+++ b/ASCII Decorator.py
@@ -17,11 +17,31 @@ else:
 
 PACKAGE_LOCATION = os.path.abspath(os.path.dirname(__file__))
 
-
 class FontPreviewGeneratorCommand(sublime_plugin.WindowCommand):
-    def run(self, text):
+    def run(self, text = "Lorem Ipsum", use_selected_text = False):
         # Find directory locations
         font_locations = figlet_paths()
+
+        # Verify selected text
+        if use_selected_text == True:
+
+            view = self.window.active_view()
+            selections = view.sel()
+            region_count = len( selections )
+
+            if region_count == 0 or region_count > 1:
+                return
+
+            selection = selections[0]
+            line_a = view.line( selection.a )
+            line_b = view.line( selection.b )
+            if line_a != line_b: return
+
+            text = view.substr( selection )
+            text = text.strip()
+
+            if text == "":
+                return
 
         # Find available fonts
         self.options = []

--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -6,8 +6,9 @@
         [
             {"command": "figlet_default", "caption": "Default Font" },
             {"command": "figlet_menu", "caption": "Font Selector"},
-            {"command": "figlet_favorites", "caption": "Font Favorites"}
-        ]
+            {"command": "figlet_favorites", "caption": "Font Favorites"},
+            {"command": "font_preview_generator", "args": { "use_selected_text": true }, "caption": "Generate Font Test From Selection"}
+         ]
     },
     { "caption": "-"}
 ]

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -12,8 +12,13 @@
         "command": "figlet_favorites"
     },
     {
-        "caption": "ASCII Decorator: Generate Font Test",
+        "caption": "ASCII Decorator: Generate Font Test (Selected Text)",
         "command": "font_preview_generator",
-        "args": { "text": "Lorem Ipsum" }
-    }
+        "args": {"use_selected_text": true}
+    },
+    {
+        "caption": "ASCII Decorator: Generate Font Test (Lorem Ipsum)",
+        "command": "font_preview_generator",
+        "args": {"text": "Lorem Ipsum"}
+    },
 ]


### PR DESCRIPTION
Redo of [**PR #27**](https://github.com/viisual/ASCII-Decorator/pull/27)

I rethought the whole line *vs* selected text argument I mentioned @ #27, and I think for the case of `FontPreviewGeneratorCommand` it actually makes sense to allow selected text, since nothing will be affected on the original view.

This implementation will use selected text if a selection is made.&nbsp; Otherwise it will use the caret's line text ( *stripped of whitespace* ).

I also implemented the same method @ `FigletCommand/run`, to address [**your usage case**](https://github.com/viisual/ASCII-Decorator/pull/28#issuecomment-205040716).

# Demo:

![ezgif-2441249850](https://cloud.githubusercontent.com/assets/10906415/14310355/78ffea46-fbaf-11e5-8fd9-9f1ec360eb95.gif)
